### PR TITLE
Make monitor_status optional to handle paused monitors

### DIFF
--- a/pythonkuma/models.py
+++ b/pythonkuma/models.py
@@ -87,7 +87,7 @@ class UptimeKumaMonitor(UptimeKumaBaseModel):
         metadata={"deserialize": lambda v: None if v == "null" else v}
     )
     monitor_response_time: int = 0
-    monitor_status: MonitorStatus
+    monitor_status: MonitorStatus | None = None
     monitor_type: MonitorType = MonitorType.HTTP
     monitor_url: str | None = field(
         metadata={"deserialize": lambda v: None if v == "null" else v}

--- a/tests/fixtures/metrics_paused.txt
+++ b/tests/fixtures/metrics_paused.txt
@@ -1,0 +1,37 @@
+# HELP monitor_cert_days_remaining The number of days remaining until the certificate expires
+# TYPE monitor_cert_days_remaining gauge
+monitor_cert_days_remaining{monitor_id="1",monitor_name="Home Assistant",monitor_type="http",monitor_url="https://home.example.com:8123",monitor_hostname="null",monitor_port="null"} 80
+
+# HELP monitor_cert_is_valid Is the certificate still valid? (1 = Yes, 0= No)
+# TYPE monitor_cert_is_valid gauge
+monitor_cert_is_valid{monitor_id="1",monitor_name="Home Assistant",monitor_type="http",monitor_url="https://home.example.com:8123",monitor_hostname="null",monitor_port="null"} 1
+
+# HELP monitor_uptime_ratio Uptime ratio calculated over sliding window specified by the 'window' label. (0.0 - 1.0)
+# TYPE monitor_uptime_ratio gauge
+monitor_uptime_ratio{monitor_id="1",monitor_name="Home Assistant",monitor_type="http",monitor_url="https://home.example.com:8123",monitor_hostname="null",monitor_port="null",window="1d"} 1
+monitor_uptime_ratio{monitor_id="1",monitor_name="Home Assistant",monitor_type="http",monitor_url="https://home.example.com:8123",monitor_hostname="null",monitor_port="null",window="30d"} 0.999247554552295
+monitor_uptime_ratio{monitor_id="1",monitor_name="Home Assistant",monitor_type="http",monitor_url="https://home.example.com:8123",monitor_hostname="null",monitor_port="null",window="365d"} 0.9944324016912971
+monitor_uptime_ratio{monitor_id="10",monitor_name="Paused Service",monitor_type="http",monitor_url="https://paused.example.com",monitor_hostname="null",monitor_port="null",window="1d"} 0.95
+monitor_uptime_ratio{monitor_id="10",monitor_name="Paused Service",monitor_type="http",monitor_url="https://paused.example.com",monitor_hostname="null",monitor_port="null",window="30d"} 0.97
+monitor_uptime_ratio{monitor_id="10",monitor_name="Paused Service",monitor_type="http",monitor_url="https://paused.example.com",monitor_hostname="null",monitor_port="null",window="365d"} 0.98
+
+# HELP monitor_response_time_seconds Average response time in seconds calculated over sliding window specified by the 'window' label
+# TYPE monitor_response_time_seconds gauge
+monitor_response_time_seconds{monitor_id="1",monitor_name="Home Assistant",monitor_type="http",monitor_url="https://home.example.com:8123",monitor_hostname="null",monitor_port="null",window="1d"} 0.10396079958463136
+monitor_response_time_seconds{monitor_id="1",monitor_name="Home Assistant",monitor_type="http",monitor_url="https://home.example.com:8123",monitor_hostname="null",monitor_port="null",window="30d"} 0.10284582478851578
+monitor_response_time_seconds{monitor_id="1",monitor_name="Home Assistant",monitor_type="http",monitor_url="https://home.example.com:8123",monitor_hostname="null",monitor_port="null",window="365d"} 0.10957428212662089
+monitor_response_time_seconds{monitor_id="10",monitor_name="Paused Service",monitor_type="http",monitor_url="https://paused.example.com",monitor_hostname="null",monitor_port="null",window="1d"} 0.42
+monitor_response_time_seconds{monitor_id="10",monitor_name="Paused Service",monitor_type="http",monitor_url="https://paused.example.com",monitor_hostname="null",monitor_port="null",window="30d"} 0.45
+monitor_response_time_seconds{monitor_id="10",monitor_name="Paused Service",monitor_type="http",monitor_url="https://paused.example.com",monitor_hostname="null",monitor_port="null",window="365d"} 0.5
+
+# HELP monitor_response_time Monitor Response Time (ms)
+# TYPE monitor_response_time gauge
+monitor_response_time{monitor_id="1",monitor_name="Home Assistant",monitor_type="http",monitor_url="https://home.example.com:8123",monitor_hostname="null",monitor_port="null"} 85
+
+# HELP monitor_status Monitor Status (1 = UP, 0= DOWN, 2= PENDING, 3= MAINTENANCE)
+# TYPE monitor_status gauge
+monitor_status{monitor_id="1",monitor_name="Home Assistant",monitor_type="http",monitor_url="https://home.example.com:8123",monitor_hostname="null",monitor_port="null"} 1
+
+# HELP app_version The service version by package.json
+# TYPE app_version gauge
+app_version{version="2.1.0",major="2",minor="1",patch="0"} 1

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -14,6 +14,13 @@ from pythonkuma.exceptions import (
     UptimeKumaConnectionException,
     UptimeKumaParseException,
 )
+from pythonkuma.models import MonitorStatus
+
+from .conftest import load_fixture
+
+LIVE_RESPONSE_TIME_MS = 85
+PAUSED_UPTIME_RATIO_1D = 0.95
+PAUSED_RESPONSE_TIME_SECONDS_1D = 0.42
 
 
 async def test_metrics(mock_session: AsyncMock, snapshot: SnapshotAssertion) -> None:
@@ -82,3 +89,35 @@ async def test_metrics_parse_exceptions(mock_session: AsyncMock) -> None:
 
     with pytest.raises(UptimeKumaParseException):
         await uptime_kuma.metrics()
+
+
+async def test_metrics_paused_monitor(mock_session: AsyncMock) -> None:
+    """Paused monitors omit ``monitor_status`` and ``monitor_response_time``.
+
+    Uptime Kuma keeps emitting the sliding-window aggregates
+    (``monitor_uptime_ratio`` and ``monitor_response_time_seconds``) for paused
+    monitors but stops emitting the live ``monitor_status`` and
+    ``monitor_response_time`` series. The parser must tolerate this and return
+    ``monitor_status = None`` for those monitors instead of crashing the whole
+    sync.
+    """
+    paused_monitor_id = 10
+    mock_session.get.return_value.text.return_value = load_fixture("metrics_paused.txt")
+    uptime_kuma = UptimeKuma(mock_session, "http://uptime.example.com", "test-apikey")
+
+    response = await uptime_kuma.metrics()
+
+    assert 1 in response
+    assert paused_monitor_id in response
+
+    live = response[1]
+    assert live.monitor_name == "Home Assistant"
+    assert live.monitor_status is MonitorStatus.UP
+    assert live.monitor_response_time == LIVE_RESPONSE_TIME_MS
+
+    paused = response[paused_monitor_id]
+    assert paused.monitor_name == "Paused Service"
+    assert paused.monitor_status is None
+    assert paused.monitor_response_time == 0
+    assert paused.monitor_uptime_ratio_1d == PAUSED_UPTIME_RATIO_1D
+    assert paused.monitor_response_time_seconds_1d == PAUSED_RESPONSE_TIME_SECONDS_1D


### PR DESCRIPTION
## Problem

When a monitor is paused in Uptime Kuma 2.x, the `/metrics` endpoint keeps emitting the sliding-window aggregates (`monitor_uptime_ratio` and `monitor_response_time_seconds` for the 1d / 30d / 365d windows) but stops emitting the live `monitor_status` and `monitor_response_time` series for that monitor.

Because `UptimeKumaMonitor.monitor_status` is required with no default, `from_dict()` raises:

```
mashumaro.exceptions.MissingField: Field "monitor_status" of type MonitorStatus is missing in UptimeKumaMonitor instance
```

One paused monitor takes down the **entire** `metrics()` call, which bubbles up to the Home Assistant `uptime_kuma` integration as `setup_retry` and turns every UK sensor unavailable. I hit this with two paused monitors in an otherwise healthy UK instance with 34 monitors; the 32 live ones never get a chance to load.

## Reproduction

Pause any monitor in UK 2.x and look at `/metrics` — you'll see the paused monitor only in `monitor_uptime_ratio` and `monitor_response_time_seconds`, missing from `monitor_status`. The new test fixture (`tests/fixtures/metrics_paused.txt`) mirrors this exactly.

## Fix

Make `monitor_status` default to `None`:

```python
-    monitor_status: MonitorStatus
+    monitor_status: MonitorStatus | None = None
```

Why `None` and not e.g. `MonitorStatus.MAINTENANCE`:

- **Paused ≠ Maintenance.** `MAINTENANCE` is the scheduled-downtime state in UK; paused is "this monitor is administratively stopped, no checks are running." Mapping paused → `MAINTENANCE` would lie to consumers.
- `None` lets downstream consumers (e.g. the HA `uptime_kuma` integration) render the sensor as unknown, which is semantically accurate.
- It mirrors the rest of the model where every field that can legitimately be absent from `/metrics` is `… | None = None` (cert, uptime_ratio, response_time_seconds).

## Test coverage

Added `test_metrics_paused_monitor` with a dedicated fixture (`metrics_paused.txt`) that contains:
- one live HTTP monitor (full metric set)
- one paused HTTP monitor (only `monitor_uptime_ratio` + `monitor_response_time_seconds`)

The test asserts that the parser:
- doesn't raise
- parses the live monitor correctly (`MonitorStatus.UP`, `response_time == 85`)
- returns `monitor_status = None` for the paused monitor while still populating the aggregates

Full suite passes (`pytest`), `ruff check` and `ruff format --check` clean. Existing snapshot test (`test_metrics`) is unaffected since the change is additive (new fixture + new test).